### PR TITLE
Design Tables on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 |email|string|null: false, unique :true, default: “”|
 
 ### Association
-- has_many :group_users
-- has_many :groups, through :group_users
+- has_many :groups_users
+- has_many :groups, through :groups_users
 - has_many :messages
 
 - - -
@@ -23,18 +23,18 @@
 |name|string|null: false, unique: true|
 
 ### Association
-- has_many :group_users
-- has_many :users, thorough: group_users
+- has_many :groups_users
+- has_many :users, thorough: groups_users
 - has_many :messages
 
 - - -
 
-## group_users Table
+## groups_users Table
 
 |Column|Type|Options|
 |---|---|---|
-|group_id|references|foreign_key: true, index: true|
-|user_id|references|foreign_key: true, index: true|
+|group_id|references|null: false, foreign_key: true, index: true|
+|user_id|references|null: false, foreign_key: true, index: true|
 
 ### Association
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@
 |---|---|---|
 |content|string|/|
 |image|string|/|
-|group_id|integer|null: false, foreign_key: true, index: true|
-|user_id|integer|null: false, foreign_key: true, index: true|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ### Association
 - has_many :group_users
 - has_many :groups, through :members
+- has_many :messages
 
 - - -
 
@@ -25,6 +26,7 @@
 ### Association
 - has_many :group_users
 - has_many :users, thorough: members
+- has_many :messages
 
 - - -
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 |---|---|---|
 |name|string|null: false, index: true, unique: true|
 |email|string|null: false, unique :true, default: “”|
-|passward|string|null: false, default: “”|
 
 ### Association
 - has_many :group_users

--- a/README.md
+++ b/README.md
@@ -1,24 +1,56 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+# chat-space Tables Design
 
-Things you may want to cover:
+## users Table
 
-* Ruby version
+|Column|Type|Options|
+|---|---|---|
+|name|string|null: false, index: true, unique: true|
+|email|string|null: false, unique :true, default: “”|
+|passward|string|null: false, default: “”|
 
-* System dependencies
+### Association
+- has_many :group_users
+- has_many :groups, through :members
 
-* Configuration
+- - -
 
-* Database creation
+## groups Table
 
-* Database initialization
+|Column|Type|Options|
+|---|---|---|
+|name|string|null: false, unique: true|
 
-* How to run the test suite
+### Association
+- has_many :group_users
+- has_many :users, thorough: members
 
-* Services (job queues, cache servers, search engines, etc.)
+- - -
 
-* Deployment instructions
+## group_users Table
 
-* ...
+|Column|Type|Options|
+|---|---|---|
+|group_id|references|foreign_key: true, index: true|
+|user_id|references|foreign_key: true, index: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+- - -
+
+## messages Table
+
+|Column|Type|Options|
+|---|---|---|
+|content|text|/|
+|image|string|/|
+|group_id|integer|null: false, foreign_key: true, index: true|
+|user_id|integer|null: false, foreign_key: true, index: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Association
 - has_many :group_users
-- has_many :groups, through :members
+- has_many :groups, through :group_users
 - has_many :messages
 
 - - -
@@ -25,7 +25,7 @@
 
 ### Association
 - has_many :group_users
-- has_many :users, thorough: members
+- has_many :users, thorough: group_users
 - has_many :messages
 
 - - -
@@ -47,7 +47,7 @@
 
 |Column|Type|Options|
 |---|---|---|
-|content|text|/|
+|content|string|/|
 |image|string|/|
 |group_id|integer|null: false, foreign_key: true, index: true|
 |user_id|integer|null: false, foreign_key: true, index: true|


### PR DESCRIPTION
下部に質問させていただければと思います。

# What
- DB設計
  - usersテーブル
  - groupsテーブル
  - group_usersテーブル
  - messagesテーブル

# Why
- テーブル構造の整理
- テーブル間の関係の整理
- カラムに付与する制約の整理

# Question
### `has_many through`と`has_many_and_belongs_to`による関連付けについて
group_usersテーブルのように外部キーのみを保持するテーブルについては、`has_many_and_belongs_to`による関連付けでも良いと書籍で見たことがあります。

ただ外部キーに関するカラムしか保持できないという理由から、基本的には、「`has_many`の`through`オプションによって多対多の関連付けを行う」という理解でいいのでしょうか。

